### PR TITLE
Add support for output entities in CSV configuration

### DIFF
--- a/maltego_trx/decorator_registry.py
+++ b/maltego_trx/decorator_registry.py
@@ -25,7 +25,7 @@ from maltego_trx.utils import (
 TRANSFORMS_CSV_HEADER = (
     "Owner,Author,Disclaimer,Description,Version,"
     "Name,UIName,URL,entityName,"
-    "oAuthSettingId,transformSettingIDs,seedIDs"
+    "oAuthSettingId,transformSettingIDs,seedIDs,outputEntities"
 )
 SETTINGS_CSV_HEADER = "Name,Type,Display,DefaultValue,Optional,Popup"
 
@@ -150,6 +150,7 @@ class TransformRegistry:
                 # combine global and transform scoped settings
                 ";".join(chain(meta_settings, global_settings_full_names)),
                 ";".join(self.seed_ids),
+                ";".join(transform_meta.output_entities)
             ]
 
             escaped_fields = escape_csv_fields(*transform_row)

--- a/maltego_trx/template_dir/project.py
+++ b/maltego_trx/template_dir/project.py
@@ -8,7 +8,7 @@ from maltego_trx.server import app as application
 
 register_transform_classes(transforms)
 
-registry.write_transforms_config()
+registry.write_transforms_config(include_output_entities=True)
 registry.write_settings_config()
 
 if __name__ == '__main__':

--- a/tests/test_decorator_registry.py
+++ b/tests/test_decorator_registry.py
@@ -13,6 +13,7 @@ from maltego_trx.decorator_registry import (
     TransformSetting,
     TransformRegistry,
     TRANSFORMS_CSV_HEADER,
+    LEGACY_TRANSFORMS_CSV_HEADER,
     SETTINGS_CSV_HEADER,
     TransformSet,
 )
@@ -122,6 +123,19 @@ class TransformCsvLine(NamedTuple):
     seed_ids: str
     output_entities: str
 
+class LegacyTransformCsvLine(NamedTuple):
+    owner: str
+    author: str
+    disclaimer: str
+    description: str
+    version: str
+    name: str
+    display_name: str
+    host: str
+    input_entity: str
+    oauth_id: str
+    settings_ids: str
+    seed_ids: str
 
 class SettingCsvLine(NamedTuple):
     name: str
@@ -140,9 +154,10 @@ def test_transform_to_csv(registry: TransformRegistry):
     tx_meta = registry.transform_metas.get(path_name)
     tx_settings = registry.transform_settings.get(path_name, [])
 
-    registry.write_transforms_config()
+    output_path = "./transforms_with_output_entities.csv"
+    registry.write_transforms_config(config_path=output_path,include_output_entities=True)
 
-    with open("./transforms.csv") as transforms_csv:
+    with open(output_path) as transforms_csv:
         header = next(transforms_csv)
         assert header.rstrip("\n") == TRANSFORMS_CSV_HEADER
 
@@ -163,6 +178,36 @@ def test_transform_to_csv(registry: TransformRegistry):
         assert data.seed_ids.split(";") == registry.seed_ids
         assert data.output_entities.split(";") == tx_meta.output_entities
 
+def test_transform_to_legacy_csv(registry: TransformRegistry):
+    random_class = make_transform(registry)
+
+    path_name = name_to_path(random_class.__name__)
+
+    tx_meta = registry.transform_metas.get(path_name)
+    tx_settings = registry.transform_settings.get(path_name, [])
+
+    output_path = "./transforms_no_output_entities.csv"
+    registry.write_transforms_config(config_path=output_path,include_output_entities=False)
+
+    with open(output_path) as transforms_csv:
+        header = next(transforms_csv)
+        assert header.rstrip("\n") == LEGACY_TRANSFORMS_CSV_HEADER
+
+        line = next(transforms_csv).rstrip("\n")
+        data: LegacyTransformCsvLine = LegacyTransformCsvLine(*line.split(","))
+
+        assert data.owner == registry.owner
+        assert data.author == registry.author
+        assert data.disclaimer == tx_meta.disclaimer
+        assert data.description == tx_meta.description
+        assert data.version == registry.version
+        assert data.name == tx_meta.class_name
+        assert data.display_name == tx_meta.display_name
+        assert data.host == os.path.join(registry.host_url, "run", path_name)
+        assert data.input_entity == tx_meta.input_entity
+        assert data.oauth_id == registry.oauth_settings_id
+        assert data.settings_ids.split(";") == [s.id for s in tx_settings]
+        assert data.seed_ids.split(";") == registry.seed_ids
 
 def test_setting_to_csv(registry: TransformRegistry):
     local_setting = make_transform_setting(global_setting=False)

--- a/tests/test_decorator_registry.py
+++ b/tests/test_decorator_registry.py
@@ -120,6 +120,7 @@ class TransformCsvLine(NamedTuple):
     oauth_id: str
     settings_ids: str
     seed_ids: str
+    output_entities: str
 
 
 class SettingCsvLine(NamedTuple):
@@ -160,6 +161,7 @@ def test_transform_to_csv(registry: TransformRegistry):
         assert data.oauth_id == registry.oauth_settings_id
         assert data.settings_ids.split(";") == [s.id for s in tx_settings]
         assert data.seed_ids.split(";") == registry.seed_ids
+        assert data.output_entities.split(";") == tx_meta.output_entities
 
 
 def test_setting_to_csv(registry: TransformRegistry):


### PR DESCRIPTION
-     Added support for output entity types to existing codebase
-     Updated TRANSFORMS_CSV_HEADER constant to include new outputEntities field
-     Updated TransformCsvLine named tuple to include new output_entities field
-     Updated _create_transforms_config method to include output_entities field in list of transformed values
-     Updated test_transform_to_csv method to assert output_entities field in TransformCsvLine named tuple matches expected output entities

Change allows for output entity types to be included in output CSV when generating transforms configuration