### PR TITLE
Bump dependencies (notably cryptography>=39.0.1 and flask>=2.2.0)

### DIFF
--- a/.github/workflows/pythonx-boot-check.yaml
+++ b/.github/workflows/pythonx-boot-check.yaml
@@ -1,6 +1,9 @@
 name: 'Runs with Python3.6 - Python3.10'
 
-on: [ push ]
+on:
+  pull_request_target:
+    branches:
+      - 'master'
 
 jobs:
   boots:

--- a/.github/workflows/pythonx-boot-check.yaml
+++ b/.github/workflows/pythonx-boot-check.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6.x', '3.7.x', '3.8.x', '3.9.x', '3.10.x' ]
+        python-version: [ '3.8.x', '3.9.x', '3.10.x' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pythonx-pytest.yaml
+++ b/.github/workflows/pythonx-pytest.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6.x', '3.7.x', '3.8.x', '3.9.x', '3.10.x' ]
+        python-version: [ '3.8.x', '3.9.x', '3.10.x' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pythonx-pytest.yaml
+++ b/.github/workflows/pythonx-pytest.yaml
@@ -1,6 +1,9 @@
 name: 'PyTest with Python3.6 - Python3.10'
 
-on: [ push ]
+on:
+  pull_request_target:
+    branches:
+      - 'master'
 
 jobs:
   pytest:

--- a/.github/workflows/sonatype-jack.yml
+++ b/.github/workflows/sonatype-jack.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6.x', '3.10.x' ]
+        python-version: [ '3.8.x', '3.9.x', '3.10.x' ]
 
     steps:
       - uses: actions/checkout@v2
@@ -19,9 +19,6 @@ jobs:
 
       - name: Run jake from Sonatype
         run: |
-          # needed for Python3.6
-          export PYTHONIOENCODING=utf-8
-          
           python -m pip install --upgrade pip
           pip3 install -r requirements.txt
           pip3 freeze > frozen.requirements.txt

--- a/.github/workflows/sonatype-jack.yml
+++ b/.github/workflows/sonatype-jack.yml
@@ -1,6 +1,9 @@
 name: 'Sonatype Jake'
 
-on: [ push ]
+on:
+  pull_request_target:
+    branches:
+      - 'master'
 
 jobs:
   security:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Maltego TRX Python Library
 
-[![Runs with Python3.6 - Python3.10](https://github.com/paterva/maltego-trx/actions/workflows/pythonx-boot-check.yaml/badge.svg)](https://github.com/paterva/maltego-trx/actions/workflows/pythonx-boot-check.yaml)
-[![PyTest with Python3.6 - Python3.10](https://github.com/paterva/maltego-trx/actions/workflows/pythonx-pytest.yaml/badge.svg)](https://github.com/paterva/maltego-trx/actions/workflows/pythonx-pytest.yaml)
+[![Runs with Python3.8 - Python3.10](https://github.com/paterva/maltego-trx/actions/workflows/pythonx-boot-check.yaml/badge.svg)](https://github.com/paterva/maltego-trx/actions/workflows/pythonx-boot-check.yaml)
+[![PyTest with Python3.8 - Python3.10](https://github.com/paterva/maltego-trx/actions/workflows/pythonx-pytest.yaml/badge.svg)](https://github.com/paterva/maltego-trx/actions/workflows/pythonx-pytest.yaml)
 [![Sonatype Jake](https://github.com/paterva/maltego-trx/actions/workflows/sonatype-jack.yml/badge.svg)](https://github.com/paterva/maltego-trx/actions/workflows/sonatype-jack.yml)
 
 ## Release Notes
+
+__1.6.1__: Update cryptography and Flask dependency and deprecate Python 3.7
 
 __1.6.0__: Automatically generate am `.mtz` for your local transforms
 
@@ -22,7 +24,7 @@ __1.4.2__: Fixed python3.6 incompatibility
 
 ## Getting Started
 
-_Note: Support for Python 2 has been officially discontinued as of July 2021. Please use Python 3.6 or higher to use
+_Note: Support for Python 2 has been officially discontinued as of July 2021. Please use Python 3.8 or higher to use
 up-to-date versions of Maltego TRX._
 
 To install the trx library run the following command:

--- a/maltego_trx/__init__.py
+++ b/maltego_trx/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "1.6.0"
+VERSION = "1.6.1"

--- a/maltego_trx/utils.py
+++ b/maltego_trx/utils.py
@@ -7,8 +7,6 @@ from typing import TypeVar, Callable, Hashable, Iterable, Generator, Sequence
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
 
-from six import text_type, binary_type
-
 logger = logging.getLogger("maltego-trx")
 
 
@@ -39,12 +37,12 @@ def make_printable(val):
 
 
 def force_encoding(val, encoding):
-    if type(val) == text_type:
+    if isinstance(val, str):
         return val.encode(encoding, 'replace').decode(encoding, 'replace')
-    elif type(val) == binary_type:
+    elif isinstance(val, bytes):
         return val.decode(encoding, 'replace')
     else:
-        return text_type(val).encode(encoding, 'replace').decode(encoding, 'replace')
+        return str(val).encode(encoding, 'replace').decode(encoding, 'replace')
 
 
 def remove_invalid_xml_chars(val):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 flask>=2.2.3
-six>=1.16.0
 cryptography==39.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-flask>=1
-six>=1
-cryptography==3.3.2 # pinned for now as newer versions require setuptools_rust
-dataclasses==0.8; python_version < "3.7"
+flask>=2.2.3
+six>=1.16.0
+cryptography==39.0.1

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
     license='MIT',
     install_requires=[
         'flask>=2.2.0',
-        'six>=1.0.0',
         'cryptography>=39.0.1'
     ],
     packages=[

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,9 @@ setup(
     author_email='support@maltego.com',
     license='MIT',
     install_requires=[
-        'flask>=1',
-        'six>=1',
-        'cryptography==3.3.2'  # pinned for now as newer versions require setuptools_rust
+        'flask>=2.2.0',
+        'six>=1.0.0',
+        'cryptography>=39.0.1'
     ],
     extras_require={
         ':python_version == "3.6"': [

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ with open("README.md", "r") as readme_md:
 
 setup(
     name='maltego-trx',
+    python_requires='>=3.8.0',
     version=VERSION,
     description='Python library used to develop Maltego transforms',
     long_description=long_description,
@@ -19,11 +20,6 @@ setup(
         'six>=1.0.0',
         'cryptography>=39.0.1'
     ],
-    extras_require={
-        ':python_version == "3.6"': [
-            'dataclasses',
-        ],
-    },
     packages=[
         'maltego_trx',
         'maltego_trx/template_dir',


### PR DESCRIPTION
Superseeds #48 

Pinned working dependencies in requirements.txt and minimum requirements in setup.py:

- Cryptography >= 39.0.1
- Flask >= 2.2.0